### PR TITLE
Log expected star positions and add identified star toggle

### DIFF
--- a/calibration/stars.py
+++ b/calibration/stars.py
@@ -85,6 +85,8 @@ def visible_stars(
             "alt": alt,
             "az": az,
             "magnitude": magnitude_value,
+            "ra": star.ra_deg,
+            "dec": star.dec_deg,
         })
     visible.sort(key=lambda item: -item["alt"])
     return visible
@@ -117,6 +119,8 @@ def project_stars(
             "alt": star["alt"],
             "az": star["az"],
             "magnitude": star["magnitude"],
+            "ra": star["ra"],
+            "dec": star["dec"],
             "x": float(x),
             "y": float(y),
         })

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,7 @@
           <label><input type="checkbox" id="toggleDetections" checked /> Mostrar detecciones</label>
           <label><input type="checkbox" id="toggleExpected" checked /> Mostrar posiciones esperadas</label>
           <label><input type="checkbox" id="toggleLabels" checked /> Mostrar nombres</label>
+          <label><input type="checkbox" id="toggleIdentified" checked /> Mostrar identificadas</label>
         </div>
         <div class="viewer-info" id="viewerInfo"></div>
       </section>
@@ -43,10 +44,10 @@
             <h2>Datos de la captura</h2>
             <form id="observationForm" class="form-grid">
               <label>Latitud
-                <input type="number" step="0.0001" id="latitude" required placeholder="Ej. 41.387" />
+                <input type="number" step="any" id="latitude" required placeholder="Ej. 41.387" />
               </label>
               <label>Longitud
-                <input type="number" step="0.0001" id="longitude" required placeholder="Ej. 2.168" />
+                <input type="number" step="any" id="longitude" required placeholder="Ej. 2.168" />
               </label>
               <label>Altitud (m)
                 <input type="number" step="1" id="elevation" value="0" />


### PR DESCRIPTION
## Summary
- expose RA/Dec from projected stars so downloaded matches include expected coordinates and sky positions
- log projected star pixel positions, recolor matched detections, and add a “mostrar identificadas” toggle
- allow high precision latitude/longitude input while rounding stored values to six decimals

## Testing
- python -m compileall app calibration

------
https://chatgpt.com/codex/tasks/task_e_68da5b7ffc2c83249407891d05a6b6b9